### PR TITLE
find_me_mode.py: display targets' relative bearing, distance, and 𝚫elevation

### DIFF
--- a/src/find_me_mode.py
+++ b/src/find_me_mode.py
@@ -3,7 +3,7 @@ find_me_mode.py
 
 This file is for an alternate targeting mode where target match locations are provided in relative terms (bearing, distance, elevation change) for use by on the ground search and rescue teams, short-distance indirect fire teams (e.g. mortars) and the like
 
-nA single fixed location may be specified either using WGS84 Geodetic Lat/Lon or NATO MGRS (with altitude optional).
+A single fixed location may be specified either using WGS84 Geodetic Lat/Lon or NATO MGRS (with altitude optional).
 
 If desired, Magnetic Declination can be optionally specified so that the target bearing will be output in magnetic heading (instead of true heading), e.g. for use with a handheld analog compass. This is not necessary for most digital compasses (e.g. a smartphone)
 
@@ -309,9 +309,12 @@ def find_me_mode():
 
             tarY, tarX, tarZ = this[2][1], this[2][2], this[2][3]
             brng = haversine_bearing(lon, lat, tarX, tarY)
-            print(f"{'Magnetic Bearing' if mag != 0.0 else 'Bearing'}: {round(brng + mag,2)}" + "°" + f" {'(' + ('+' if mag > 0 else '') + str(mag)+'°)' if mag != 0.0 else ''}")
+            print(f"{'Magnetic Bearing 🧭' if mag != 0.0 else 'Bearing'}: {round(brng + mag,2)}" + "°" + f" {'(' + ('+' if mag > 0 else '') + str(mag)+'°)' if mag != 0.0 else ''}")
             rangeToTarget = haversine(lon, lat, tarX, tarY, alt)
-            print(f"Range: {round(rangeToTarget)}")
+            print(f"Range 🏹 : {round(rangeToTarget)}m")
+
+            deltaZ = tarZ - alt
+            print(f"𝚫 Altitude⛰️ : {round(deltaZ)}m")
 
             files_prosecuted.append(this[1])
 

--- a/src/find_me_mode.py
+++ b/src/find_me_mode.py
@@ -173,7 +173,6 @@ def find_me_mode():
         if alt is None:
             errstr = "FATAL ERROR: could not determine your altitude!"
             sys.exit(errstr)
-        alt = decimal.Decimal(float(alt))
 
         warnStr = '\033[1;31;m' #ANSI escape sequence, bold and red
         warnStr += "WARNING: you did not input your current altitude\n"
@@ -183,6 +182,8 @@ def find_me_mode():
         warnStr +="\n"
         print(warnStr)
         time.sleep(4)
+
+    alt = decimal.Decimal(float(alt))
 
     if directory is None:
         directory = os.getcwd()
@@ -346,8 +347,8 @@ def find_me_mode():
                 # target elevation does not change, even with windage adjustment
                 print(f"𝚫 Elevation⛰️ : {'+' if deltaZ > 0 else ''}{round(deltaZ)}m")
                 print("")
-                print(f'Nadjust: {Nadjust}')
-                print(f'Eadjust: {Eadjust}')
+                print(f'Nadjust: {Nadjust}m')
+                print(f'Eadjust: {Eadjust}m')
                 print("")
                 print("   N ")
                 print("   ↑ ")

--- a/src/find_me_mode.py
+++ b/src/find_me_mode.py
@@ -182,7 +182,7 @@ def find_me_mode():
         warnStr +="\033[0;0m" #ANSI escape sequence, reset terminal to normal colors
         warnStr +="\n"
         print(warnStr)
-        time.sleep(2)
+        time.sleep(4)
 
     if directory is None:
         directory = os.getcwd()
@@ -328,7 +328,7 @@ def find_me_mode():
 
             inkey = _Getch()
 
-            while not '   ' in ch:
+            while not ' ' in ch:
                 clear()
                 print(f'Target🎯:{imgName}')
                 print(f'Date/Time🕰️ :{dateTime}')
@@ -354,8 +354,8 @@ def find_me_mode():
                 print("W ←↓→ E")
                 print("   S ")
                 print("")
-                print("Windage💨: use ←↓↑→ to adjust, RETURN x3 (↩↩↩) to reset")
-                print("Press SPACEBAR x3 switch to newest available target")
+                print("Windage💨: use ←↓↑→ to adjust, RETURN (↩) to reset")
+                print("Press SPACEBAR (' ') switch to newest available target")
 
                 if 'MAX' in imgName:
                     warnStr = '\033[1;31;m' #ANSI escape sequence, bold and red
@@ -367,7 +367,11 @@ def find_me_mode():
 
                 while(True):
                     ch = inkey()
+                    if ch == '\x1b': # char \x1b
+                        ch += inkey() # char [
+                        ch += inkey() # char in {A, B, C, D}
                     if ch != '': break
+                print(str(ch))
                 if ch == '\x1b[A':
                     Nadjust += decimal.Decimal(4.0)
                 elif ch == '\x1b[B':
@@ -376,7 +380,7 @@ def find_me_mode():
                     Eadjust += decimal.Decimal(4.0)
                 elif ch == '\x1b[D':
                     Eadjust -= decimal.Decimal(4.0)
-                elif '\r\r\r' in ch:
+                elif '\r' in ch:
                     Nadjust = 0
                     Eadjust = 0
 
@@ -429,7 +433,7 @@ class _GetchUnix:
         old_settings = termios.tcgetattr(fd)
         try:
             tty.setraw(sys.stdin.fileno())
-            ch = sys.stdin.read(3)
+            ch = sys.stdin.read(1)
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
         return ch

--- a/src/find_me_mode.py
+++ b/src/find_me_mode.py
@@ -314,7 +314,7 @@ def find_me_mode():
             print(f"Range 🏹 : {round(rangeToTarget)}m")
 
             deltaZ = tarZ - alt
-            print(f"𝚫 Altitude⛰️ : {'+' if deltaZ > 0 else ''}{round(deltaZ)}m")
+            print(f"𝚫 Elevation⛰️ : {'+' if deltaZ > 0 else ''}{round(deltaZ)}m")
 
             files_prosecuted.append(this[1])
 

--- a/src/find_me_mode.py
+++ b/src/find_me_mode.py
@@ -149,6 +149,7 @@ def find_me_mode():
         warnStr +="\033[0;0m" #ANSI escape sequence, reset terminal to normal colors
         warnStr +="\n"
         print(warnStr)
+        time.sleep(2)
 
     if lat is None or lon is None:
         errstr = f'FATAL ERROR: no location specified, please use --lat YY.YYYY --lon XX.XXXX (WGS84)'
@@ -181,6 +182,7 @@ def find_me_mode():
         warnStr +="\033[0;0m" #ANSI escape sequence, reset terminal to normal colors
         warnStr +="\n"
         print(warnStr)
+        time.sleep(2)
 
     if directory is None:
         directory = os.getcwd()

--- a/src/find_me_mode.py
+++ b/src/find_me_mode.py
@@ -10,7 +10,7 @@ If desired, Magnetic Declination can be optionally specified so that the target 
 Only intended for short range distances, otherwise will be inaccurate (curvature of the earth, great circle distance, etc.)
 
 """
-import sys, tty, termios
+import sys
 import os
 import time
 import datetime

--- a/src/find_me_mode.py
+++ b/src/find_me_mode.py
@@ -314,7 +314,7 @@ def find_me_mode():
             print(f"Range 🏹 : {round(rangeToTarget)}m")
 
             deltaZ = tarZ - alt
-            print(f"𝚫 Altitude⛰️ : {'+' if alt > 0 else ''}{round(deltaZ)}m")
+            print(f"𝚫 Altitude⛰️ : {'+' if deltaZ > 0 else ''}{round(deltaZ)}m")
 
             files_prosecuted.append(this[1])
 

--- a/src/find_me_mode.py
+++ b/src/find_me_mode.py
@@ -314,7 +314,7 @@ def find_me_mode():
             print(f"Range 🏹 : {round(rangeToTarget)}m")
 
             deltaZ = tarZ - alt
-            print(f"𝚫 Altitude⛰️ : {round(deltaZ)}m")
+            print(f"𝚫 Altitude⛰️ : {'+' if alt > 0 else ''}{round(deltaZ)}m")
 
             files_prosecuted.append(this[1])
 

--- a/src/getTarget.py
+++ b/src/getTarget.py
@@ -484,6 +484,34 @@ def haversine(lon1, lat1, lon2, lat2, alt):
     r = decimal.Decimal(r)
     return c * r
 
+"""takes two lat/lon pairs (a start A and a destination B) and finds the heading of the shortest direction of travel from A to B
+Note: this function will work with Geodetic coords of any ellipsoid (as long as both pairs' ellipsoid are the same)
+
+adapted from https://stackoverflow.com/a/64747209
+
+Parameters
+----------
+lon1 : float
+    longitude of the first point
+lat1 : float
+    latitude of the first point
+lon2 : float
+    longitude of the second point
+lat2 : float
+    latitude of the second point
+
+"""
+def haversine_bearing(lon1, lat1, lon2, lat2):
+    dLon = (lon2 - lon1)
+    x = math.cos(math.radians(lat2)) * math.sin(math.radians(dLon))
+    y = math.cos(math.radians(lat1)) * math.sin(math.radians(lat2)) - math.sin(math.radians(lat1)) * math.cos(math.radians(lat2)) * math.cos(math.radians(dLon))
+    brng = math.atan2(x,y)
+    brng = normalize(brng)
+    brng = math.degrees(brng)
+
+    return brng
+
+
 """takes a decimal +/- Lat and Lon and returns a tuple of two strings containing Degrees Minutes Seconds each
 
 Note: this funtion will work with Geodetic coords of any ellipsoid

--- a/src/getTarget.py
+++ b/src/getTarget.py
@@ -429,6 +429,9 @@ alt : float
     the approximate altitude, added to the radius of the great circle
 """
 def inverse_haversine(point, distance, azimuth, alt):
+    if distance < 0.0:
+        # reverse direction and make distance a positive number
+        return inverse_haversine(point, -distance, normalize(azimuth + math.pi), alt)
     lat, lon = point
     lat, lon = map(math.radians, (lat, lon))
     d = distance

--- a/src/getTarget.py
+++ b/src/getTarget.py
@@ -269,6 +269,8 @@ def resolveTarget(y, x, z, azimuth, theta, elevationData, xParams, yParams):
     #     below us:
     if math.isclose((math.pi / 2), theta):
         terrainAlt = parseGeoTIFF.getAltFromLatLon(y, x, xParams, yParams, elevationData)
+        if terrainAlt is None:
+            return None
         finalDist = z - terrainAlt
         if finalDist < 0:
             print(f'\n ERROR: bad calculation!\n')
@@ -329,14 +331,14 @@ def resolveTarget(y, x, z, azimuth, theta, elevationData, xParams, yParams):
     curZ = decimal.Decimal(z)
     groundAlt = parseGeoTIFF.getAltFromLatLon(curY, curX, xParams, yParams, elevationData)
     if groundAlt is None:
-        print(f'ERROR: resolveTarget ran out of bounds at {round(curY,4)}, {round(curX,4)}, {round(curZ,4)}m', file=sys.stderr)
+        print(f'ERROR: resolveTarget ran out of bounds at {round(curY,4)}, {round(curX,4)}, {round(curZ,1)}m', file=sys.stderr)
         print('ERROR: Please ensure target location is within GeoTIFF dataset bounds', file=sys.stderr)
         return None
     altDiff = curZ - groundAlt
     while altDiff > threshold:
         groundAlt = parseGeoTIFF.getAltFromLatLon(curY, curX, xParams, yParams, elevationData)
         if groundAlt is None:
-            print(f'ERROR: resolveTarget ran out of bounds at {round(curY,4)}, {round(curX,4)}, {round(curZ,4)}m', file=sys.stderr)
+            print(f'ERROR: resolveTarget ran out of bounds at {round(curY,4)}, {round(curX,4)}, {round(curZ,1)}m', file=sys.stderr)
             print('ERROR: Please ensure target location is within GeoTIFF dataset bounds', file=sys.stderr)
             return None
         altDiff = curZ - groundAlt

--- a/src/mortar_mode.py
+++ b/src/mortar_mode.py
@@ -1,0 +1,157 @@
+"""
+mortar_mode.py
+
+This file is for an alternate targeting mode where target match locations are provided in relative terms (bearing, distance, elevation change) for use by short-distance indirect fire teams (e.g. mortars)
+
+The mortar location may be specified either using WGS84 Geodetic Lat/Lon or NATO MGRS (with altitude optional).
+
+If desired, Magnetic Declination can be optionally specified so that the target bearing will be output in magnetic heading (instead of true heading), e.g. for use with a handheld analog compass. This is not necessary for most digital compasses (e.g. a smartphone)
+
+Only intended for short range distances, otherwise will be inaccurate (curvature of the earth, great circle distance, etc.)
+
+"""
+import sys
+import time
+import math
+from math import sin, asin, cos, atan2, sqrt
+import decimal # more float precision with Decimal objects
+
+from osgeo import gdal # en.wikipedia.org/wiki/GDAL
+
+# https://pypi.org/project/mgrs/
+import mgrs # Military Grid ref converter
+
+from PIL import Image
+from PIL import ExifTags
+
+from parseGeoTIFF import getAltFromLatLon, binarySearchNearest
+from getTarget import *
+from parseImage import *
+
+def mortar_mode():
+    images = []
+
+    elevationData = None
+    x0, dx, dxdy, y0, dydx, dy = [None] * 6
+    x1 = y1 = None
+    nrows = ncols = None
+    xParams = yParams = [None] * 4
+    geofilename = None
+
+    m = mgrs.MGRS()
+
+    lat = None
+    lon = None
+    my_mgrs = None
+    alt = None
+    mag = 0.0
+
+    if len(sys.argv) <= 1:
+        errstr = f'FATAL ERROR: no location specified, please use --lat YY.YYYY --lon XX.XXXX (WGS84)'
+        sys.exit(errstr)
+
+    for i in range(len(sys.argv)):
+        segment = sys.argv[i]
+        if segment.lower() == "--lat":
+            if i + 1 >= len(sys.argv):
+                sys.exit("Fatal ERROR: expected value after '--lat'")
+            else:
+                lat = sys.argv[i + 1]
+            try:
+                lat = float(lat)
+            except ValueError:
+                errstr = f"FATAL ERROR: expected Latitude, got: {lat}"
+                sys.exit(errstr)
+        elif segment.lower() == "--lon":
+            if i + 1 >= len(sys.argv):
+                sys.exit("Fatal ERROR: expected value after '--lon'")
+            else:
+                lon = sys.argv[i + 1]
+            try:
+                lon = float(lon)
+            except ValueError:
+                errstr = f"FATAL ERROR: expected Longitude, got: {lon}"
+                sys.exit(errstr)
+        elif segment.lower() == "--mgrs":
+            if i + 1 >= len(sys.argv):
+                sys.exit("Fatal ERROR: expected value after '--mgrs'")
+            else:
+                my_mgrs = sys.argv[i + 1]
+            try:
+                lat, lon = m.toLatLon(my_mgrs)
+            except:
+                errstr = f"FATAL ERROR: expected NATO MGRS, got: {my_mgrs}"
+                sys.exit(errstr)
+        elif segment.lower() == "--mag":
+            if i + 1 >= len(sys.argv):
+                sys.exit("Fatal ERROR: expected value after '--mag'")
+            else:
+                mag = sys.argv[i + 1]
+            try:
+                mag = float(mag)
+            except ValueError:
+                errstr = f"FATAL ERROR: expected compass mag declination, got: {mag}"
+                sys.exit(errstr)
+        elif segment.lower() == "--alt":
+            if i + 1 >= len(sys.argv):
+                sys.exit("Fatal ERROR: expected value after '--alt'")
+            else:
+                alt = sys.argv[i + 1]
+            try:
+                alt = float(alt)
+            except ValueError:
+                errstr = f"FATAL ERROR: expected WGS84 altitude, got: {alt}"
+                sys.exit(errstr)
+        elif segment.split('.')[-1].lower() == "tif":
+            geofilename = segment
+            elevationData, (x0, dx, dxdy, y0, dydx, dy) = getGeoFileFromString(geofilename)
+            nrows, ncols = elevationData.shape
+            x1 = x0 + dx * ncols
+            y1 = y0 + dy * nrows
+            ensureValidGeotiff(dxdy, dydx)
+            xParams = (x0, x1, dx, ncols)
+            yParams = (y0, y1, dy, nrows)
+
+    #end for loop
+
+    mag = -1 * mag # instead of magnetic -> true heading, we go true -> magnetic (so we must invert)
+    if mag != 0.0:
+        warnStr = '\033[1;31;m' #ANSI escape sequence, bold and red
+        warnStr += f"WARNING: adjusting target headings by {mag}° for use with analog magnetic compass\n"
+        warnStr += "    please ensure this offset direction is correct and your compass decl. is set to 0°"
+        warnStr +="\033[0;0m" #ANSI escape sequence, reset terminal to normal colors
+        warnStr +="\n"
+        print(warnStr)
+
+    if lat is None or lon is None:
+        errstr = f'FATAL ERROR: no location specified, please use --lat YY.YYYY --lon XX.XXXX (WGS84)'
+        sys.exit(errstr)
+
+    if elevationData is None:
+        errstr = "FATAL ERROR: no valid GeoTIFF (.tif) Digital Elevation Model provided!"
+        sys.exit(errstr)
+
+    if (lat > y0 or lat < y1) or (lon < x0 or lon > x1):
+        errstr = f"FATAL ERROR: {round(lat,6)}, {round(lon,6)} is outside of GeoTIFF coverage area\n"
+        errstr += f"    Please ensure you are using the correct file\n"
+        errstr += f"    Your Location: {round(lat,4)}, {round(lon,4)}\n"
+        errstr += f"    {geofilename}:\n"
+        errstr += f"        {round(y1,6)} < lat < {round(y0,6)}\n"
+        errstr += f"        {round(x0,6)} < lon < {round(x1,6)}\n"
+        sys.exit(errstr)
+
+    if alt is None:
+        alt = getAltFromLatLon(lat, lon, xParams, yParams, elevationData)
+
+        warnStr = '\033[1;31;m' #ANSI escape sequence, bold and red
+        warnStr += "WARNING: you did not input your current altitude\n"
+        warnStr += f"    using value {alt}m according to nearest GeoTIFF DEM datapoint\n"
+        warnStr += "    your GPS reading may be more accurate than this value"
+        warnStr +="\033[0;0m" #ANSI escape sequence, reset terminal to normal colors
+        warnStr +="\n"
+        print(warnStr)
+
+    # @TODO process targets here
+
+if __name__ == "__main__":
+    mortar_mode()

--- a/src/mortar_mode.py
+++ b/src/mortar_mode.py
@@ -54,7 +54,7 @@ def mortar_mode():
         segment = sys.argv[i]
         if segment.lower() == "--lat":
             if i + 1 >= len(sys.argv):
-                sys.exit("Fatal ERROR: expected value after '--lat'")
+                sys.exit("FATAL ERROR: expected value after '--lat'")
             else:
                 lat = sys.argv[i + 1]
             try:
@@ -64,7 +64,7 @@ def mortar_mode():
                 sys.exit(errstr)
         elif segment.lower() == "--lon":
             if i + 1 >= len(sys.argv):
-                sys.exit("Fatal ERROR: expected value after '--lon'")
+                sys.exit("FATAL ERROR: expected value after '--lon'")
             else:
                 lon = sys.argv[i + 1]
             try:
@@ -74,7 +74,7 @@ def mortar_mode():
                 sys.exit(errstr)
         elif segment.lower() == "--mgrs":
             if i + 1 >= len(sys.argv):
-                sys.exit("Fatal ERROR: expected value after '--mgrs'")
+                sys.exit("FATAL ERROR: expected value after '--mgrs'")
             else:
                 my_mgrs = sys.argv[i + 1]
             try:
@@ -84,13 +84,18 @@ def mortar_mode():
                 sys.exit(errstr)
         elif segment.lower() == "--mag":
             if i + 1 >= len(sys.argv):
-                sys.exit("Fatal ERROR: expected value after '--mag'")
+                sys.exit("FATAL ERROR: expected value after '--mag'")
             else:
                 mag = sys.argv[i + 1]
+
             try:
                 mag = float(mag)
             except ValueError:
                 errstr = f"FATAL ERROR: expected compass mag declination, got: {mag}"
+                sys.exit(errstr)
+
+            if mag < -180.0 or mag > 360.0:
+                errstr = f"FATAL ERROR: compas mag declination out of range"
                 sys.exit(errstr)
         elif segment.lower() == "--alt":
             if i + 1 >= len(sys.argv):
@@ -117,7 +122,7 @@ def mortar_mode():
     mag = -1 * mag # instead of magnetic -> true heading, we go true -> magnetic (so we must invert)
     if mag != 0.0:
         warnStr = '\033[1;31;m' #ANSI escape sequence, bold and red
-        warnStr += f"WARNING: adjusting target headings by {mag}° for use with analog magnetic compass\n"
+        warnStr += f"WARNING: adjusting target headings by {'+' if mag > 0 else ''}{mag}° for use with analog magnetic compass\n"
         warnStr += "    please ensure this offset direction is correct and your compass decl. is set to 0°"
         warnStr +="\033[0;0m" #ANSI escape sequence, reset terminal to normal colors
         warnStr +="\n"

--- a/src/parseImage.py
+++ b/src/parseImage.py
@@ -563,7 +563,7 @@ exifData: Dict
     expressed as key:value pairs
 """
 def handleAUTEL(xmp_str, exifData):
-    warnStr = '\033[1;31;m' #ANSI escape sequence, underlined and red
+    warnStr = '\033[1;31;m' #ANSI escape sequence, bold and red
     warnStr += 'USER WARNING: in-accuracies have been observed from Autels\'\n'
     warnStr += '    reported altitude, azimuth, and theta. This may result in bad target res.\n\n'
     warnStr += '    PROCEED WITH CAUTION '


### PR DESCRIPTION
# Find Me Mode:

## Summary:

[`find_me_mode.py`](./src/find_me_mode.py) provides an alternate targeting mode where target match locations are provided in relative terms (bearing, distance, elevation change) from a fixed point for use by on the ground search and rescue teams, short-distance indirect fire teams (e.g. mortars) and the like

A single fixed location  may be specified either using a conventional WGS84 Latitude/Longitude pair or a NATO MGRS (with altitude optional).

If desired, [Magnetic Declination](https://ngdc.noaa.gov/geomag/declination.shtml) can be optionally specified (using the `--mag` flag) so that the target bearing will be output in magnetic heading (instead of true heading), e.g. for use with a handheld analog compass. This is not necessary for most digital compasses (e.g. a smartphone)

This mode is only intended for short range distances, otherwise will be inaccurate (curvature of the earth, etc.)

## Usage:
The drone photo `DJI_0419.JPG` and the [GeoTIFF Digital Elevation Model](https://github.com/mkrupczak3/OpenAthena/blob/main/EIO_fetch_geotiff_example.md) `cobb.tif` come included in the `./src` directory of this software for demonstration

<img width="726" alt="Screen Shot 2022-08-07 at 1 09 05 PM" src="https://user-images.githubusercontent.com/25494111/183302754-e8732ea6-083e-4bfb-af6d-ca6ed7129f01.png">

### Mandatory arguments:
[`find_me_mode.py`](./src/find_me_mode.py) _must_ be provided a GeoTIFF DEM (ending in `.tif`) and a fixed location (using the flags `--lat` and `--lon`, or alternatively `--mgrs`) for successful operation

### Optional arguments:
The user may optionally provide a magnetic declination, altitude from sea level, and/or a directory on their filesystem to scan using `--mag`, `--alt`, and `--dir` respectively.

`--mag` represents magnetic declination as the necessary [adjustment on a magnetic compass heading](https://ngdc.noaa.gov/geomag/declination.shtml) to obtain a true heading. If this value _is not_ provided, find_me_mode will output any elative targets according to its true heading. Alternatively: if a value _is_ provided by the user, this will be used to convert each calculated true heading to a magnetic heading (e.g. for use with a handheld analog compass). Because [this adjustment](https://ngdc.noaa.gov/geomag/faqgeom.shtml#How_do_I_correct_my_compass_bearing_to_true_bearing) is done to convert (true heading) → (magnetic heading) instead of (magnetic heading) → (true heading), the sign of the adjustment is the opposite of that provided by the user in the `--mag` flag. The user should **exercise great caution and verify** that the sign of this adjustment is as intended to avoid undefined software behavior

`--alt` represents the altitude from sea level in meters (WGS84) of the user's fixed location to use for providing the relative coordinates of targets. This may be obtained easily from a handheld GPS, including a smartphone. If this value is not provided, find_me_mode will use the terrain altitude of the nearest datapoint from the provided GeoTIFF Digital Elevation Model (.tif). It is highly recommended that the user provides their GPS altitude here as it will be more accurate (especially if the user's altitude differs significantly from ground-level, such as on the roof of a tall building)

`--dir` represents the directory (folder) on the user's filesystem to scan for drone images. find_me_mode will scan all images in this directory, then it will provide the newest image available (according to the EXIF `DateTime` tag) as a target with relative coordinates. find_me_mode will re-scan the directory and repeat this process after each target is prosecuted until no more targets remain. If this value _is not_ provided, find_me_mode will attempt to use the current working directory of the user's session on their respective operating system. Alternatively: if this value _is_ provided, find_me_mode will use this directory to scan for drone images.

## Operation:
find_me_mode will provide a distinct user warning if the `--mag` flag **is** used and/or the `--alt` flag **is not** used:
<img width="732" alt="Screen Shot 2022-08-07 at 2 21 38 PM" src="https://user-images.githubusercontent.com/25494111/183305423-86283273-1bce-4b22-94f3-312574e9e061.png">


A few seconds later, the following output will appear on the terminal interface:
<img width="565" alt="Screen Shot 2022-08-07 at 1 05 54 PM" src="https://user-images.githubusercontent.com/25494111/183302604-3d80b918-9afc-4580-b435-4b41caf0cda7.png">

### output information

`Target🎯` displays the filename of the drone image currently provided as a target

`Date/Time🕰️` displays the value of the EXIF `DateTime` flag of the target's image (usually in local time)

`Bearing` displays the true heading from the user towards the target (in degrees)

`Magnetic Bearing 🧭` if the `--mag` flag is used, this will appear in place of `Bearing:`. This displays the magnetic heading from the user towards the target (in degrees)

`Range 🏹 ` displays the horizontal range (in meters) from the user towards the target (e.g. for use in ballistic calculation). May be inaccurate over very-long distances where the curvature of the earth must be taken into account

`𝚫 Elevation⛰️ ` displays the vertical change (in meters) in elevation from the user towards the target

### windage adjustment

A windage adjustment can be applied to the target location to compensate for windage or other factors. Windage adjustment can be applied in increments of 4 meters (about one car's length) north, east, south, or west using each respective arrow key on the keyboard. 

`Nadjust` represents the adjustment of the target location (in meters) north or south to compensate for windage or other factors.

`Eadjust` represents the adjustment of the target location (in meters) east or west to compensate for windage or other factors.

### prosecuting multiple targets
find_me_mode will find the newest available image to use as a target after each target is prosecuted. The user may press the SPACEBAR (' ') key to mark the current target as prosecuted and switch to the newest available target. By default, windage adjustments will persist to the display of the next target. The RETURN key (↩) may be used to reset `Nadjust` and `Eadjust` windage adjustments to 0m each. 

### Autel sensor data warning
Numerous in-accuracies have been observed in the sensor metadata of images taken by drones made by Autel Robotics. In many cases, this may result in in-accurate target resolutions. To inform the user of possible incorrect target resolutions, a prominent warning will appear in the output if the image filename contains `MAX`, as is the case by default for images taken by the Autel Evo II. At present only the filename is used to make this check and not the EXIF Make tag value

# Background:

[`parseImage.py`](https://github.com/mkrupczak3/OpenAthena/blob/main/drone_sensor_data_blurb.md) allows for the extraction and use of metadata from drone images to pinpoint a precise location to which a drone's camera is aiming at (in the exact center of the image frame)

![image showing terminal output from parseImage.py specifying a precise location resolution from the center of a drone image](https://raw.githubusercontent.com/mkrupczak3/OpenAthena/main/assets/parseImage_interactive_example3.png)

![zoomed image of thompson park drone photo, compared side by side with Google Maps of resolved location. The center point of the drone photo on the left is marked with a small red circle](https://raw.githubusercontent.com/mkrupczak3/OpenAthena/main/assets/pretty_good.jpg)

paresImage.py may provide the absolute location of each target resolution as a Lat/Lon pair with altitude, a NATO MGRS with altitude, or a SK42 Geodetic or Gauss-Krüger value with SK42 altitude. While such target resolutions may prove ideal for use by long range artillery systems with digital fire control systems, target locations in absolute terms are difficult to use by small indirect fire teams (e.g. mortars) or search and rescue teams on the ground. 

find_me_mode.py was created with the intention to provide more timely, relevant information to an operator of OpenAthena. find_me_mode allows an operator to continuously prosecute the newest available target, even while new target images are being added in real time. Each target's location is provided in relative terms (Bearing, Range, 𝚫elevation) to facilitate more immediate use

