### PR TITLE
Remove GDAL library, replace with Python geotiff library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM debian:stable-slim
 LABEL maintainer="Matthew Krupczak <matthew@krupczak.org>"
 RUN echo $(cat /etc/*release*)
 
-RUN apt-get update -y && sed -i 's/stable\/updates/stable-security\/updates/' /etc/apt/sources.list && DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing --no-install-recommends python3-pip${APT_ARCH_SUFFIX}
+RUN sed -i 's/stable\/updates/stable-security\/updates/' /etc/apt/sources.list
+RUN apt-get update -y
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing --no-install-recommends python3-pip${APT_ARCH_SUFFIX}
 RUN echo $(pip3 --version)
 
 RUN useradd -ms /bin/bash user
@@ -20,4 +22,4 @@ COPY src/DJI_0419.JPG .
 
 VOLUME /home/user
 
-ENTRYPOINT [ "python", "parseImage.py"]
+ENTRYPOINT [ "python3", "parseImage.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:stable-slim
 LABEL maintainer="Matthew Krupczak <matthew@krupczak.org>"
 RUN echo $(cat /etc/*release*)
 
-RUN apt-get update -y && DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing --no-install-recommends python3-pip${APT_ARCH_SUFFIX}
+RUN apt-get update -y && sed -i 's/stable\/updates/stable-security\/updates/' /etc/apt/sources.list && DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing --no-install-recommends python3-pip${APT_ARCH_SUFFIX}
 RUN echo $(pip3 --version)
 
 RUN useradd -ms /bin/bash user

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,6 @@
-FROM osgeo/gdal:ubuntu-small-3.5.0
+FROM debian:stable-slim
 LABEL maintainer="Matthew Krupczak <matthew@krupczak.org>"
 RUN echo $(cat /etc/*release*)
-# # ----------GDAL-STUFF----------
-# RUN apt-get update
-# RUN apt-get upgrade -y
-
-# RUN echo deb https://ftp.debian.org/debian unstable main contrib non-free >> /etc/apt/sources.list
-# RUN apt-get update
-
-# RUN apt-get remove -y binutils
-
-# RUN apt-get -t unstable install -y libgdal-dev g++
-
-# ENV CPLUS_INCLUDE_PATH=/usr/include/gdal
-# ENV C_INCLUDE_PATH=/usr/include/gdal
-
-# # RUN pip install pygdal~=3.2.0 #included in requirenments.txt instead
-# # ----------END-GDAL-STUFF----------
 
 RUN apt-get update -y && DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing --no-install-recommends python3-pip${APT_ARCH_SUFFIX}
 RUN echo $(pip3 --version)
@@ -26,7 +10,6 @@ USER user
 WORKDIR /home/user
 
 COPY requirements.txt .
-
 
 RUN pip3 install -r requirements.txt && rm requirements.txt
 

--- a/README.md
+++ b/README.md
@@ -103,22 +103,28 @@ Ensure your version of `pip` is up to date:
 python3 -m pip install --upgrade pip
 ```
 
-Install the GDAL package with your package manager (i.e. apt, yum, brew, pacman, etc.):
-
-Example (MacOS):
+Then, download this repository to your computer (requires [git](https://github.com/git-guides/install-git)):
 ```bash
-brew install gdal
-```
-
-Then, all you need to do is run `pip3 install matplotlib mgrs pillow`, then run `src/parseGeoTIFF.py` with python3:
-```bash
-pip3 install matplotlib mgrs pillow
 git clone https://github.com/mkrupczak3/OpenAthena.git
-cd OpenAthena/src
-python3 parseGeoTIFF.py
+cd OpenAthena
 ```
 
-"pip3" and "python3" may just be called "pip" and "python" depending on the configuration of your system
+Once inside the OpenAthena directory, install all pre-requisistes with `pip`:
+```bash
+python3 -m pip install -r requirements.txt
+```
+
+then run `src/parseGeoTIFF.py` with python3 to test your installation:
+```bash
+cd src
+python3 parseGeoTIFF.py Rome-30m-DEM.tif
+```
+
+You should see output [like this](https://github.com/mkrupczak3/OpenAthena#parsegeotiffpy)
+
+If you encounter an error, please submit an issue to the OpenAthena GitHub page
+
+Note: "python3" may just be called "python" depending on the configuration of your system
 
 # Usage:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# pygdal~=3.2.0
+geotiff~=0.2.7
 matplotlib~=3.5.1
 mgrs~=1.4.5
 pillow~=9.0.1

--- a/src/find_me_mode.py
+++ b/src/find_me_mode.py
@@ -24,7 +24,7 @@ from osgeo import gdal # en.wikipedia.org/wiki/GDAL
 # https://pypi.org/project/mgrs/
 import mgrs # Military Grid ref converter
 
-import tkinter
+# import tkinter
 
 from PIL import Image
 from PIL import ExifTags
@@ -138,7 +138,8 @@ def find_me_mode():
             nrows, ncols = elevationData.shape
             x1 = x0 + dx * ncols
             y1 = y0 + dy * nrows
-            ensureValidGeotiff(dxdy, dydx)
+            # # had to remove this check switching from gdal -> geotiff libraries :(
+            # ensureValidGeotiff(dxdy, dydx)
             xParams = (x0, x1, dx, ncols)
             yParams = (y0, y1, dy, nrows)
 
@@ -199,7 +200,7 @@ def find_me_mode():
     Nadjust = decimal.Decimal(0.0)
     Eadjust = decimal.Decimal(0.0)
 
-    rootTk = tkinter.Tk()
+    # rootTk = tkinter.Tk()
 
     while True: # only break if list is empty after file walk
         files_queued = []

--- a/src/find_me_mode.py
+++ b/src/find_me_mode.py
@@ -15,8 +15,8 @@ import os
 import time
 import datetime
 import math
-import numpy
 from math import sin, asin, cos, atan2, sqrt
+import numpy as np
 import decimal # more float precision with Decimal objects
 
 from osgeo import gdal # en.wikipedia.org/wiki/GDAL

--- a/src/getTarget.py
+++ b/src/getTarget.py
@@ -15,6 +15,7 @@ from geotiff import GeoTiff # alternative to gdal for parsing GeoTiff .tif files
 import mgrs # Military Grid ref converter
 import math
 from math import sin, asin, cos, atan2, sqrt
+import numpy as np
 import decimal # more float precision with Decimal objects
 
 import parseGeoTIFF
@@ -136,6 +137,19 @@ def getGeoFileFromString(geofilename):
     # elevationData = band.ReadAsArray()
     elevationData = geoFile.read()
 
+    try:
+        # convert to numpy array for drastic in-memory perf increase
+        elevationData = np.array(elevationData)
+    except MemoryError:
+        # it is possible, though highly unlikely,
+        #     ...that a very large geotiff may exceed memory bounds
+        #        this should only happen on 32-bit Python runtime
+        #        or computers w/ very little RAM
+        #
+        # performance will be severely impacted
+        elevationData = None
+        elevationData = geodata.read()
+
     x0 = geoFile.tifTrans.get_x(0,0)
     dx = geoFile.tifTrans.get_x(1,0) - x0
     y0 = geoFile.tifTrans.get_y(0,0)
@@ -179,6 +193,20 @@ def getGeoFileFromUser():
     # elevationData = band.ReadAsArray()
 
     elevationData = geoFile.read()
+
+    try:
+        # convert to numpy array for drastic in-memory perf increase
+        elevationData = np.array(elevationData)
+    except MemoryError:
+        # it is possible, though highly unlikely,
+        #     ...that a very large geotiff may exceed memory bounds
+        #        this should only happen on 32-bit Python runtime
+        #        or computers w/ very little RAM
+        #
+        # performance will be severely impacted
+        elevationData = None
+        elevationData = geodata.read()
+
     x0 = geoFile.tifTrans.get_x(0,0)
     dx = geoFile.tifTrans.get_x(1,0) - x0
     y0 = geoFile.tifTrans.get_y(0,0)

--- a/src/getTarget.py
+++ b/src/getTarget.py
@@ -10,7 +10,8 @@ This file will focus on the core math of resolving the location
 
 import time
 import matplotlib.pyplot as plt
-from osgeo import gdal # Lots of good GeoINT stuff
+# from osgeo import gdal # Lots of good GeoINT stuff
+from geotiff import GeoTiff # alternative to gdal for parsing GeoTiff .tif files
 import mgrs # Military Grid ref converter
 import math
 from math import sin, asin, cos, atan2, sqrt
@@ -41,7 +42,8 @@ def getTarget():
     x1 = x0 + dx * ncols
     y1 = y0 + dy * nrows
 
-    ensureValidGeotiff(dxdy, dydx)
+    # # had to remove this check switching from gdal -> geotiff libraries :(
+    # ensureValidGeotiff(dxdy, dydx)
 
     print(f'x0: {round(x0,4)} dx: {round(dx,9)} ncols: {round(ncols,4)} x1: {round(x1,4)}')
     print(f'y0: {round(y0,4)} dy: {round(dy,9)} nrows: {round(nrows,4)} y1: {round(y1,4)}\n\n')
@@ -124,14 +126,27 @@ def getTarget():
 """
 def getGeoFileFromString(geofilename):
     geofilename.strip()
-    geoFile = gdal.Open(geofilename)
+    # geoFile = gdal.Open(geofilename)
+    geoFile = GeoTiff(geofilename)
     if geoFile is None:
         outstr = f'FATAL ERROR: can\'t find file with name \'{geofilename}\''
         sys.exit(outstr)
 
-    band = geoFile.GetRasterBand(1)
-    elevationData = band.ReadAsArray()
-    return elevationData, geoFile.GetGeoTransform()
+    # band = geoFile.GetRasterBand(1)
+    # elevationData = band.ReadAsArray()
+    elevationData = geoFile.read()
+
+    x0 = geoFile.tifTrans.get_x(0,0)
+    dx = geoFile.tifTrans.get_x(1,0) - x0
+    y0 = geoFile.tifTrans.get_y(0,0)
+    dy = geoFile.tifTrans.get_y(0,1) - y0
+    # dxdy, dydx will be != 0 if image is rotated or skewed
+    #     unfortunately, I can't figure out how to check this after switching from
+    #     ...library 'gdal' to 'geotiff'
+    dxdy = dydx = 0
+    geoTransform = (x0, dx, dxdy, y0, dydx, dy)
+
+    return elevationData, geoTransform
 
 """prompt the user for the entry of a GeoTIFF filename
     if filename is invalid, will re-prompt
@@ -151,7 +166,8 @@ def getGeoFileFromUser():
             continue
         else:
             try:
-                geoFile = gdal.Open(geofilename)
+                # geoFile = gdal.Open(geofilename) # old 'gdal' invocation
+                geoFile = GeoTiff(geofilename) # new 'geotiff' invocation
             except:
                 print(f'ERROR: can\'t find file with name \'{geofilename}\'')
                 geoFile = None
@@ -159,32 +175,43 @@ def getGeoFileFromUser():
                 continue
     #
 
-    band = geoFile.GetRasterBand(1)
-    elevationData = band.ReadAsArray()
-    return elevationData, geoFile.GetGeoTransform()
+    # band = geoFile.GetRasterBand(1)
+    # elevationData = band.ReadAsArray()
 
-"""check if a geoTiff is invalid, i.e. rotated or skewed
+    elevationData = geoFile.read()
+    x0 = geoFile.tifTrans.get_x(0,0)
+    dx = geoFile.tifTrans.get_x(1,0) - x0
+    y0 = geoFile.tifTrans.get_y(0,0)
+    dy = geoFile.tifTrans.get_y(0,1) - y0
+    # dxdy, dydx will be != 0 if image is rotated or skewed
+    #     unfortunately, I can't figure out how to check this after switching from
+    #     ...library 'gdal' to 'geotiff'
+    dxdy = dydx = 0
+    geoTransform = (x0, dx, dxdy, y0, dydx, dy)
 
-Parameters
-----------
-dxdy : float
-    might be the rate of x change per unit y
-    if this is not 0, we have a problem!
-dydx : float
-    might be the rate of y change per unit x
-    if this is not 0, we have a problem!
-"""
-def ensureValidGeotiff(dxdy, dydx):
-    # I'm making the assumption that the image isn't rotated/skewed/etc.
-    # This is not the correct method in general, but let's ignore that for now
-    # If dxdy or dydx aren't 0, then this will be incorrect
-    # we cannot deal with rotated or skewed images in current version
-    if dxdy != 0 or dydx != 0:
-        outstr = "FATAL ERROR: GeoTIFF is rotated or skewed!"
-        outstr += "\ncannot proceed with file: "
-        outstr += geofilename
-        print(outstr, file=sys.stderr)
-        sys.exit(outstr)
+    return elevationData, geoTransform
+
+# """check if a geoTiff is invalid, i.e. rotated or skewed
+# Parameters
+# ----------
+# dxdy : float
+#     might be the rate of x change per unit y
+#     if this is not 0, we have a problem!
+# dydx : float
+#     might be the rate of y change per unit x
+#     if this is not 0, we have a problem!
+# """
+# def ensureValidGeotiff(dxdy, dydx):
+#     # I'm making the assumption that the image isn't rotated/skewed/etc.
+#     # This is not the correct method in general, but let's ignore that for now
+#     # If dxdy or dydx aren't 0, then this will be incorrect
+#     # we cannot deal with rotated or skewed images in current version
+#     if dxdy != 0 or dydx != 0:
+#         outstr = "FATAL ERROR: GeoTIFF is rotated or skewed!"
+#         outstr += "\ncannot proceed with file: "
+#         outstr += geofilename
+#         print(outstr, file=sys.stderr)
+#         sys.exit(outstr)
 
 """handle user input of data, using message for prompt
     guaranteed to return a float in range

--- a/src/parseGeoTIFF.py
+++ b/src/parseGeoTIFF.py
@@ -4,6 +4,7 @@ import matplotlib.pyplot as plt
 from geotiff import GeoTiff
 import math
 from math import sin, asin, cos, atan2, sqrt
+import numpy as np
 import decimal # more float precision with Decimal objects
 import getTarget
 # import numpy
@@ -40,6 +41,20 @@ def main():
     # band = geodata.GetRasterBand(1)
 
     elevation = geodata.read()
+
+    try:
+        # convert to numpy array for drastic in-memory perf increase
+        elevation = np.array(elevation)
+    except MemoryError:
+        # it is possible, though highly unlikely,
+        #     ...that a very large geotiff may exceed memory bounds
+        #        this should only happen on 32-bit Python runtime
+        #        or computers w/ very little RAM
+        #
+        # performance will be severely impacted
+        elevation = None
+        elevation = geodata.read()
+
 
     print("The shape of the elevation data is: ", elevation.shape)
     time.sleep(1)

--- a/src/parseGeoTIFF.py
+++ b/src/parseGeoTIFF.py
@@ -1,6 +1,7 @@
 import time
 import matplotlib.pyplot as plt
-from osgeo import gdal
+# from osgeo import gdal
+from geotiff import GeoTiff
 import math
 from math import sin, asin, cos, atan2, sqrt
 import decimal # more float precision with Decimal objects
@@ -33,10 +34,12 @@ def main():
     # based on:
     # stackoverflow.com/a/24957068
 
-    geodata = gdal.Open(geofile)
+    # geodata = gdal.Open(geofile)
+    geodata = GeoTiff(geofile)
 
-    band = geodata.GetRasterBand(1)
-    elevation = band.ReadAsArray()
+    # band = geodata.GetRasterBand(1)
+
+    elevation = geodata.read()
 
     print("The shape of the elevation data is: ", elevation.shape)
     time.sleep(1)
@@ -59,17 +62,17 @@ def main():
     # I'm making the assumption that the image isn't rotated/skewed/etc.
     # This is not the correct method in general, but let's ignore that for now
     # If dxdy or dydx aren't 0, then this will be incorrect
-    x0, dx, dxdy, y0, dydx, dy = geodata.GetGeoTransform()
+    # x0, dx, dxdy, y0, dydx, dy = geodata.GetGeoTransform()
+    x0 = geodata.tifTrans.get_x(0,0)
+    dx = geodata.tifTrans.get_x(1,0) - x0
+    y0 = geodata.tifTrans.get_y(0,0)
+    dy = geodata.tifTrans.get_y(0,1) - y0
+    dxdy = dydx = 0
 
     # This should help with type conversion
     # mx+b ?
     x1 = x0 + dx * ncols
     y1 = y0 + dy * nrows
-
-    # # Dumb identity scalar for debugging
-    # # Doesn't work, don't use this
-    # x1 = 1
-    # y1 = 1
 
     print(f'x0: {round(x0,4)} dx: {round(dx,9)} ncols: {round(ncols,4)} x1: {round(x1,4)}')
     print(f'y0: {round(y0,4)} dy: {round(dy,9)} nrows: {round(nrows,4)} y1: {round(y1,4)}')
@@ -137,8 +140,6 @@ def getAltFromLatLon(lat, lon, xParams, yParams, elevation):
     # for now we will just use the elevation of the nearest datapoint
     e1, e2, e3, e4 = elevation[yT][xL], elevation[yB][xL], elevation[yT][xR], elevation[yB][xR]
     meanE = (e1 + e2 + e3 + e4) / 4
-    # # Slightly less accurate, but still okay
-    # return meanE
 
     # note here that xL, xR, yT, and yB are all index positions of
     # elevation and not yet in degrees lat/lon

--- a/src/parseImage.py
+++ b/src/parseImage.py
@@ -33,7 +33,8 @@ import math
 from math import sin, asin, cos, atan2, sqrt
 import decimal # more float precision with Decimal objects
 
-from osgeo import gdal # en.wikipedia.org/wiki/GDAL
+# from osgeo import gdal # en.wikipedia.org/wiki/GDAL
+from geotiff import GeoTiff
 # https://pypi.org/project/mgrs/
 import mgrs # Military Grid ref converter
 # # # https://pypi.org/project/pyproj/

--- a/src/parseImage.py
+++ b/src/parseImage.py
@@ -97,8 +97,8 @@ def parseImage():
         print(f'x0: {round(x0,4)} dx: {round(dx,9)} ncols: {round(ncols,4)} x1: {round(x1,4)}')
         print(f'y0: {round(y0,4)} dy: {round(dy,9)} nrows: {round(nrows,4)} y1: {round(y1,4)}\n\n')
 
-
-    ensureValidGeotiff(dxdy, dydx)
+    # # had to remove this check switching from gdal -> geotiff libraries :(
+    # ensureValidGeotiff(dxdy, dydx)
 
     xParams = (x0, x1, dx, ncols)
     yParams = (y0, y1, dy, nrows)


### PR DESCRIPTION
The official [GDAL](https://gdal.org/) library is an extensive suite of open-source GEOINT tools for use by professionals. 

The OpenAthena project has made use of this library as a pre-requisite so far, but some issues arise due to the following:

- Installing GDAL with the python `pygdal` library fails on multiple OS's (and has for some time) with no known fix
- GDAL can only be installed with the OS's package manager. This is a problem for OS's like Mac and Windows which do not come with a package manager by default

Therefore, to improve the process of installing and using this software the [GDAL Library](https://gdal.org/) will be excised and replaced with @KipCrossing's python [geotiff](https://pypi.org/project/geotiff/) library

This library is narrower in scope and is viable for extracting a usable Digital Elevation Model from a given GeoTIFF