### PR TITLE
Add example_script.py for how to use OpenAthena with custom Python scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ OpenAthena™ is a project which allows consumer and professional drones to spot
 
 🖼️👨‍💻 + 🧮⛰️ = 🎯📍
 
-OpenAthena may prove especially useful for life-saving civilian search and rescue (SAR) and other commercial applications. For military use, this technique may greatly reduce the incidence of errors during the process of [forward artillery observation](https://en.wikipedia.org/wiki/Artillery_observer). This may profoundly reduce harm to civilian lives and property in warfare.
+OpenAthena may prove especially useful for life-saving civilian search and rescue (SAR) and other applications.
 
-This software is in pre-alpha. Use appropriate caution when using data generated from this program.
+This Python version of OpenAthena is a legacy product which will have limited support in the future. [OpenAthena™ for Android](https://github.com/mkrupczak3/bOpenAthenaAndroid) is a superior implementation of this project. Please follow updates from [Theta Informatics LLC](https://theta.limited) regarding a replacement OpenAthena-Core library which will be written in Java. Take note of the open GitHub issues and use appropriate caution when using data generated from this program.
 
 ## OpenAthena™ for Android
 
@@ -154,6 +154,10 @@ CAUTION: it is _**highly recommended**_ that the aircraft's compass sensor is ca
 More info [**here**](drone_sensor_data_blurb.md)
 
 <a href="drone_sensor_data_blurb.md"><img width="565" alt="image of command line on MacOS, showing a target location calculated by OpenAthena parseImage.py" src="./assets/parseImage_interactive_example3.png"></a>
+
+### example_script.py
+
+[example_script.py](./src/example_script.py) contains an example script showing how you may use OpenAthena in your own code. Make sure to follow the [**installation**](https://github.com/mkrupczak3/OpenAthena#install) instructions shown previously. The only required files for this scripts usage are a DEM file (such as the default Rome-30m-DEM.tif), and the Python code files [parseGeoTIFF.py](./src/parseGeoTIFF.py), and [getTarget.py](./src/getTarget.py)
 
 ### find_me_mode.py
 
@@ -325,17 +329,10 @@ The values should be tested for correctness
 The program `getTarget.py` will then exit
 
 
-
-
-# Military Uses
-Especially when employed with precision smart munitions (e.g. [artillery](https://asc.army.mil/web/portfolio-item/ammo-excalibur-xm982-m982-and-m982a1-precision-guided-extended-range-projectile/), aerial, etc.) this project will greatly aid the safety and processes of the [forward artillery observer](https://en.wikipedia.org/wiki/Artillery_observer) while reducing collateral damage. This technique attempts to minimize the risk of operator error (mismeasurement, miscalculation, etc.) and subsequent risk of friendly-fire and loss of civilian life.
-
-In addition: a passive optical-based approach to target identification does not emit any signature which may forewarn a target or a group of targets (including armored vehicles). This may be highly beneficial depending on the usage environment.
-
-
 # Civilian Uses
 
 This technology can be used for search and rescue operations, wildfire detection and management, measuring and surveying for civic engineering, and many other commercial purposes.
+
 
 # US Arms export control notice
 This software falls under the [Dual Use Technology](https://en.wikipedia.org/wiki/Dual-use_technology#United_States) category under applicable U.S. arms export control laws. If you are using this software in a country that is under restriction from the United States under the Arms Export Control Act, you may only use this for civilian purposes and may not use this software in conflict. This author is not responsible for unauthorized usage of this open source project

--- a/README.md
+++ b/README.md
@@ -157,7 +157,9 @@ More info [**here**](drone_sensor_data_blurb.md)
 
 ### example_script.py
 
-[example_script.py](./src/example_script.py) contains an example script showing how you may use OpenAthena in your own code. Make sure to follow the [**installation**](https://github.com/mkrupczak3/OpenAthena#install) instructions shown previously. The only required files for this scripts usage are a DEM file (such as the default Rome-30m-DEM.tif), and the Python code files [parseGeoTIFF.py](./src/parseGeoTIFF.py), and [getTarget.py](./src/getTarget.py)
+[example_script.py](./src/example_script.py) contains an example script showing how you may use OpenAthena in your own code. Make sure to follow the [**installation**](https://github.com/mkrupczak3/OpenAthena#install) instructions shown previously. The only required files for this scripts usage are a DEM file (such as the default Rome-30m-DEM.tif), and the Python code files [parseGeoTIFF.py](./src/parseGeoTIFF.py), [getTarget.py](./src/getTarget.py), and [config.py](.src/config.py)
+
+To run the script
 
 ### find_me_mode.py
 

--- a/src/example_script.py
+++ b/src/example_script.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+import sys
+import math
+from math import sin, asin, cos, atan2, sqrt
+import decimal # more float precision with Decimal objects
+from geotiff import GeoTiff
+
+from parseGeoTIFF import getAltFromLatLon, binarySearchNearest, getGeoFileFromUser, getGeoFileFromString
+from getTarget import *
+
+def main():
+    # replace this with filename of DEM you wish to use.
+    #     if it is not in the same directory as this script, you will need to
+    #     provide a complete file path.
+    DEMFILENAME = "Rome-30m-DEM.tif"
+    latitude = 41.801
+    longitude = 12.6483
+    altitude = 500 # altitude must be in EGM96 vertical datum, not WGS84
+    # azimuth represents the direction of the aircraft's camera.
+    # Starts from North @ 0°, increasing clockwise (e.g. 90° is East)
+    azimuth = 315.0
+    # theta represents degrees downwards from the horizon (forwards)
+    theta = 20.0
+
+    # Load GeoTIFF Digital Elevation Model and its parameters
+    elevationData, (x0, dx, dxdy, y0, dydx, dy) = getGeoFileFromString(DEMFILENAME)
+    nrows, ncols = elevationData.shape
+    x1 = x0 + dx * ncols
+    y1 = y0 + dy * nrows
+    xParams = (x0, x1, dx, ncols)
+    yParams = (y0, y1, dy, nrows)
+
+    # calculate target
+    target = resolveTarget(latitude, longitude, altitude, azimuth, theta, elevationData, xParams, yParams)
+
+    # break out tuple representing target into component parts
+    slantRangeToTarget, targetLat, targetLon, targetAlt, terrainAlt = target
+
+    # print out the results. Replace this with whatever output format you desire.
+    print(f'Calculated Target (lat,lon): {round(targetLat, 6)}, {round(targetLon, 6)} Alt: {round(targetAlt, 6)} meters AMSL')
+    print(f'estimated terrainAlt was: {round(terrainAlt,6)}')
+    print(f'Slant Range to Target was: {round(slantRangeToTarget,6)} meters')
+
+
+if __name__ == "__main__":
+    main()

--- a/src/find_me_mode.py
+++ b/src/find_me_mode.py
@@ -242,6 +242,8 @@ def find_me_mode():
                 elif aFile in files_prosecuted or aFile in files_queued:
                     continue
                 else:
+                    if not os.path.exists(aFile):
+                        continue
                     #from stackoverflow.com/a/14637315
                     #    if XMP in image is spread in multiple pieces, this
                     #    approach will fail to extract data in all

--- a/src/getTarget.py
+++ b/src/getTarget.py
@@ -23,8 +23,8 @@ import decimal # more float precision with Decimal objects
 import config # OpenAthena global variables
 
 import parseGeoTIFF
-from WGS84_SK42_Translator import Translator as converter # rafasaurus' SK42 coord translator
-from SK42_Gauss_Kruger import Projector as Projector      # Matt's Gauss Kruger projector for SK42 (adapted from Nickname Nick)
+# from WGS84_SK42_Translator import Translator as converter # rafasaurus' SK42 coord translator
+# from SK42_Gauss_Kruger import Projector as Projector      # Matt's Gauss Kruger projector for SK42 (adapted from Nickname Nick)
 
 """get the pos of current subject of UAS camera
        data entry is done manually
@@ -124,24 +124,24 @@ def getTarget():
         print(f'MGRS 10m: {targetMGRS10m}')
         print(f'MGRS 100m: {targetMGRS100m}\n')
 
-        targetSK42Lat = converter.WGS84_SK42_Lat(float(tarY), float(tarX), float(tarZ))
-        targetSK42Lon = converter.WGS84_SK42_Long(float(tarY), float(tarX), float(tarZ))
-        # Note: This altitude calculation assumes the SK42 and WGS84 ellipsoid have the exact same center
-        #     This is not totally correct, but in practice is close enough to the actual value
-        #     @TODO Could be refined at a later time with better math
-        #     See: https://gis.stackexchange.com/a/88499
-        targetSK42Alt = float(tarZ) - converter.SK42_WGS84_Alt(targetSK42Lat, targetSK42Lon, 0.0)
-        targetSK42Alt = int(round(targetSK42Alt))
-        print('SK42 (истема координат 1942 года):')
-        print(f'    Geodetic (°): {round(targetSK42Lat, 6)}, {round(targetSK42Lon, 6)} Alt: {targetSK42Alt}')
-        targetSK42LatDMS, targetSK42LonDMS = decimalToDegreeMinuteSecond(targetSK42Lat, targetSK42Lon)
-        print('    Geodetic (° \' "):')
-        print('      '+targetSK42LatDMS)
-        print('      '+targetSK42LonDMS)
-        GK_zone, targetSK42_N_GK, targetSK42_E_GK = Projector.SK42_Gauss_Kruger(targetSK42Lat, targetSK42Lon)
+        # targetSK42Lat = converter.WGS84_SK42_Lat(float(tarY), float(tarX), float(tarZ))
+        # targetSK42Lon = converter.WGS84_SK42_Long(float(tarY), float(tarX), float(tarZ))
+        # # Note: This altitude calculation assumes the SK42 and WGS84 ellipsoid have the exact same center
+        # #     This is not totally correct, but in practice is close enough to the actual value
+        # #     @TODO Could be refined at a later time with better math
+        # #     See: https://gis.stackexchange.com/a/88499
+        # targetSK42Alt = float(tarZ) - converter.SK42_WGS84_Alt(targetSK42Lat, targetSK42Lon, 0.0)
+        # targetSK42Alt = int(round(targetSK42Alt))
+        # print('SK42 (истема координат 1942 года):')
+        # print(f'    Geodetic (°): {round(targetSK42Lat, 6)}, {round(targetSK42Lon, 6)} Alt: {targetSK42Alt}')
+        # targetSK42LatDMS, targetSK42LonDMS = decimalToDegreeMinuteSecond(targetSK42Lat, targetSK42Lon)
+        # print('    Geodetic (° \' "):')
+        # print('      '+targetSK42LatDMS)
+        # print('      '+targetSK42LonDMS)
+        # GK_zone, targetSK42_N_GK, targetSK42_E_GK = Projector.SK42_Gauss_Kruger(targetSK42Lat, targetSK42Lon)
 
-        outstr = strFormatSK42GK(GK_zone, targetSK42_N_GK, targetSK42_E_GK, targetSK42Alt)
-        print(outstr)
+        # outstr = strFormatSK42GK(GK_zone, targetSK42_N_GK, targetSK42_E_GK, targetSK42Alt)
+        # print(outstr)
 
 """handle user input of data, using message for prompt
     guaranteed to return a float in range


### PR DESCRIPTION
This PR adds `src/example_script.py`, which contains an example which shows how to use this library with custom Python code.

Please updated README.md for further details on usage.

NOTE: this PR removes SK-42 coordinate output from `getTarget.py`. This coordinate system is not commonly used outside of Slavic and former Warsaw pact countries. Its removal is necessary to simplify the code's dependencies. 